### PR TITLE
fix: prevents links to crash app for android

### DIFF
--- a/src/components/FileImage.tsx
+++ b/src/components/FileImage.tsx
@@ -48,7 +48,9 @@ const FileImage: FC<FileImageProps> = ({
       (width, height) => {
         setImageSize({ width, height });
       },
-      (error) => console.error(error),
+      (error) => {
+        console.error('error getting the image size', error);
+      },
     );
   }, []);
 

--- a/src/components/LinkItem.tsx
+++ b/src/components/LinkItem.tsx
@@ -27,6 +27,10 @@ const LinkItem = ({
     useNavigation<ItemScreenProps<'ItemStackItem'>['navigation']>();
   const uri = item.extra.embeddedLink?.url;
 
+  const handleOpenLink = async () => {
+    return await Linking.openURL(uri);
+  };
+
   useEffect(() => {
     if (!isPlayerView) {
       navigation.setOptions({
@@ -40,23 +44,21 @@ const LinkItem = ({
     }
   }, [isPlayerView]);
 
-  const handleOpenLink = async () => {
-    return await Linking.openURL(uri);
-  };
-
   return (
     <WebView
       ref={(r) => (ref.current = r)}
       source={{ uri }}
       scalesPageToFit={false}
       startInLoadingState={true}
-      overScrollMode="never"
       cacheEnabled={true}
+      nestedScrollEnabled
       style={{
         width: dimensions.width - insets.left,
-        height: '100%',
+        // 200 prevents the webview to take the full page in player mode
+        minHeight: dimensions.height - 200,
         marginLeft: insets.left,
         marginRight: insets.right,
+        flex: 1,
       }}
     />
   );

--- a/src/components/PlayerView.tsx
+++ b/src/components/PlayerView.tsx
@@ -35,25 +35,24 @@ const PlayerView: FC<PlayerViewProps> = ({ origin, children }) => {
   }
 
   return (
+    // do not add a view here because it might contain a link - webview
     <>
-      {/* <View renderToHardwareTextureAndroid={true}> */}
       <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
         {contentItems.length === 0 ? (
           <EmptyList />
         ) : (
           contentItems.map((item) => (
             <>
-              {/* todo:padding */}
-              <PlayerItem key={item.id + 'item'} item={item} />
+              <View key={item.id + '-topspace'} style={styles.topSpace}></View>
+              <PlayerItem key={item.id + '-item'} item={item} />
               <View
-                key={item.id + 'bottomspace'}
+                key={item.id + '-bottomspace'}
                 style={styles.bottomSpace}
               ></View>
             </>
           ))
         )}
       </ScrollView>
-      {/* </View> */}
       {folderItems.length !== 0 && (
         <PlayerFolderMenu origin={origin} folderItems={folderItems} />
       )}
@@ -62,14 +61,14 @@ const PlayerView: FC<PlayerViewProps> = ({ origin, children }) => {
 };
 
 const styles = StyleSheet.create({
-  item: {
-    paddingTop: 20,
+  topSpace: {
+    height: 20,
   },
   flatList: {
     height: '100%',
   },
   bottomSpace: {
-    height: 120,
+    height: 100,
   },
 });
 

--- a/src/components/PlayerView.tsx
+++ b/src/components/PlayerView.tsx
@@ -36,20 +36,24 @@ const PlayerView: FC<PlayerViewProps> = ({ origin, children }) => {
 
   return (
     <>
-      <View>
-        <ScrollView>
-          {contentItems.length === 0 ? (
-            <EmptyList />
-          ) : (
-            contentItems.map((item) => (
-              <View key={item.id} style={styles.item}>
-                <PlayerItem item={item} />
-                <View style={styles.bottomSpace}></View>
-              </View>
-            ))
-          )}
-        </ScrollView>
-      </View>
+      {/* <View renderToHardwareTextureAndroid={true}> */}
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        {contentItems.length === 0 ? (
+          <EmptyList />
+        ) : (
+          contentItems.map((item) => (
+            <>
+              {/* todo:padding */}
+              <PlayerItem key={item.id + 'item'} item={item} />
+              <View
+                key={item.id + 'bottomspace'}
+                style={styles.bottomSpace}
+              ></View>
+            </>
+          ))
+        )}
+      </ScrollView>
+      {/* </View> */}
       {folderItems.length !== 0 && (
         <PlayerFolderMenu origin={origin} folderItems={folderItems} />
       )}


### PR DESCRIPTION
Webviews tend to crash when embedded in `<View>`s. I removed unnecessary Views. 

ref #146 